### PR TITLE
Validated the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
   "name": "drupal/htmlpurifier",
   "type": "drupal-module",
-  "description": "Drupal Commerce is a flexible eCommerce solution.",
-  "homepage": "Standards compliant HTML filter written in PHP",
+  "description": "Standards compliant HTML filter written in PHP",
+  "homepage": "https://www.drupal.org/project/htmlpurifier",
   "license": "GPL-2.0+",
   "support": {
-    "issues": "http://drupal.org/project/issues/htmlpurifier"
+    "issues": "https://www.drupal.org/project/issues/htmlpurifier"
   },
   "require": {
-    "ezyang/htmlpurifier": "4.6.0"
+    "ezyang/htmlpurifier": "4.6.*"
   }
 }


### PR DESCRIPTION
$ composer validate
./composer.json is invalid, the following errors/warnings were found:
homepage : Invalid URL format
homepage : invalid value (Standards compliant HTML filter written in PHP), must be an http/https URL

Added the homepage as the github repo url b/c there was no site for the htmlpurifier repo ? Is that fine ?

One more thing 
Can we make the htmlpurifier library version to 4.6.* because it will contain only minor fixes ?